### PR TITLE
update data-main to point to the minfied main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mkdirp": "~0.3.1",
     "ncp": "~0.2.6",
     "requirejs": "~1.0.8",
+    "almond": "~0.1.1",
     "clean-css": "~0.3.2",
     "connect": "~1.8.6",
     "grunt": "~0.3.8",

--- a/tasks/rjs.js
+++ b/tasks/rjs.js
@@ -19,6 +19,22 @@ module.exports = function(grunt) {
       };
     });
 
+    if (options.almond === true) {
+      grunt.log.ok('Including almond.js');
+      // resolve almond path
+      options.paths.almond = require.resolve('almond').replace('.js', '');
+      // include almond to each module
+      options.modules.forEach(function (module, idx) {
+        grunt.verbose.ok('Adding almond to module: ' + module.name);
+        // append almond to includes
+        if (module.include) {
+          module.include.push('almond');
+        } else {
+          module.include = ['almond'];
+        }
+      });
+    }
+
     rjs.optimize(options, function() {
       originals.forEach(function(m) {
         var filepath = path.join(options.dir, m.name + '.js');

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -105,6 +105,7 @@ module.exports = function(grunt) {
 
     grunt.log.verbose.writeln('Update the HTML to reference our concat/min/revved script files');
     content = grunt.helper('replace', content, /<script.+src=['"](.+)["'][\/>]?><[\\]?\/script>/gm);
+    content = grunt.helper('replace', content, /<script.+data-main=['"](.+)["'].*src=.*[\/>]?><[\\]?\/script>/gm);
 
     grunt.log.verbose.writeln('Update the HTML with the new css filenames');
     content = grunt.helper('replace', content, /<link rel=["']?stylesheet["']?\shref=['"](.+)["']\s*>/gm);

--- a/tasks/usemin.js
+++ b/tasks/usemin.js
@@ -106,6 +106,15 @@ module.exports = function(grunt) {
     grunt.log.verbose.writeln('Update the HTML to reference our concat/min/revved script files');
     content = grunt.helper('replace', content, /<script.+src=['"](.+)["'][\/>]?><[\\]?\/script>/gm);
     content = grunt.helper('replace', content, /<script.+data-main=['"](.+)["'].*src=.*[\/>]?><[\\]?\/script>/gm);
+    if (grunt.config('rjs.almond')) {
+      content = content.replace(/<script.+data-main=['"](.+)["'].*src=.*[\/>]?><[\\]?\/script>/gm, function(match, src) {
+        var res = match.replace(/\s*src=['"].*["']/gm, '').replace('data-main', 'src');
+        grunt.log.ok('almond')
+          .writeln('was ' + match)
+          .writeln('now ' + res);
+        return res;
+      });
+    }
 
     grunt.log.verbose.writeln('Update the HTML with the new css filenames');
     content = grunt.helper('replace', content, /<link rel=["']?stylesheet["']?\shref=['"](.+)["']\s*>/gm);


### PR DESCRIPTION
On RequireJS projects, the build script must update both `src` and `data-main` attributes of the `script` tag to point to the minified versions. Now it does.
